### PR TITLE
Support sound files from any search path

### DIFF
--- a/addons/sourcemod/scripting/saysounds.sp
+++ b/addons/sourcemod/scripting/saysounds.sp
@@ -1036,10 +1036,7 @@ public runSoundEvent(Handle:event,const String:type[],const String:extra[],const
 			else
 				KvGetString(listfile, "playto",playto,sizeof(playto),"RoundEvent");
 
-			// Used for identifying the names of things
-			//PrintToChatAll("Found Subkey, trying to match (%s) with (%s)",extra,extraparam);
-			
-			if(!IsGameSound(location) && !checkSamplingRate(location))
+			if (FileExists(location) && !checkSamplingRate(location))
 				return false;
 			
 			if(StrEqual(extra, extraparam, false))// && checkSamplingRate(location))
@@ -1584,34 +1581,29 @@ Send_Sound(client, const String:filelocation[], const String:name[], bool:joinso
 	
 	new timebuf;
 	new samplerate;
-	
-	if (!IsGameSound(filelocation)){
-		new Handle:h_Soundfile = INVALID_HANDLE;
-		h_Soundfile = OpenSoundFile(filelocation,true);
+	new Handle:h_Soundfile = OpenSoundFile(filelocation, true);
 
-		if(h_Soundfile != INVALID_HANDLE)
-		{
-			// get the sound length
-			timebuf = GetSoundLength(h_Soundfile);
-			// get the sample rate
-			samplerate = GetSoundSamplingRate(h_Soundfile);
-			// close the handle
-			CloseHandle(h_Soundfile);
-		}
-		else
-			LogError("<Send_Sound> INVALID_HANDLE for file \"%s\" ", filelocation);
+	if (h_Soundfile != INVALID_HANDLE)
+	{
+		// get the sound length
+		timebuf = GetSoundLength(h_Soundfile);
+		// get the sample rate
+		samplerate = GetSoundSamplingRate(h_Soundfile);
+		// close the handle
+		CloseHandle(h_Soundfile);
+	}
+	else
+		LogError("<Send_Sound> INVALID_HANDLE for file \"%s\" ", filelocation);
 
-		// Check the sample rate and leave a message if it's above 44.1 kHz;
-		if (samplerate > 44100)
-		{
-			LogError("Invalid sample rate (\%d Hz) for file \"%s\", sample rate should not be above 44100 Hz", samplerate, filelocation);
-			PrintToChat(client, "\x04[Say Sounds] \x01Invalid sample rate (\x04%d Hz\x01) for file \x04%s\x01, sample rate should not be above \x0444100 Hz", samplerate, filelocation);
-			return;
-		}
+	// Check the sample rate and leave a message if it's above 44.1 kHz;
+	if (FileExists(filelocation) && samplerate > 44100)
+	{
+		LogError("Invalid sample rate (\%d Hz) for file \"%s\", sample rate should not be above 44100 Hz", samplerate, filelocation);
+		PrintToChat(client, "\x04[Say Sounds] \x01Invalid sample rate (\x04%d Hz\x01) for file \x04%s\x01, sample rate should not be above \x0444100 Hz", samplerate, filelocation);
+		return;
 	}
 
 	new Float:duration = float(timebuf);
-
 	new Float:defVol = GetConVarFloat(cvarvolume);
 	new Float:volume = KvGetFloat(listfile, "volume", defVol);
 	if (volume == 0.0 || volume == 1.0)

--- a/addons/sourcemod/scripting/saysounds/checks.sp
+++ b/addons/sourcemod/scripting/saysounds/checks.sp
@@ -24,39 +24,6 @@ bool:HasClientFlags (const String:flags[], client)
 	return false;
 }
 
-public IsGameSound (const String:file[])
-{
-	if (!strncmp(file, "ambient", 7) ||
-		!strncmp(file, "beams", 5) ||
-		!strncmp(file, "buttons", 7) ||
-		!strncmp(file, "coach", 5) ||
-		!strncmp(file, "combined", 8) ||
-		!strncmp(file, "commentary", 10) ||
-		!strncmp(file, "common", 6) ||
-		!strncmp(file, "doors", 5) ||
-		!strncmp(file, "friends", 7) ||
-		!strncmp(file, "hl1", 3) ||
-		!strncmp(file, "items", 5) ||
-		!strncmp(file, "midi", 4) ||
-		!strncmp(file, "misc", 4) ||
-		!strncmp(file, "music", 5) ||
-		!strncmp(file, "npc", 3) ||
-		!strncmp(file, "physics", 7) ||
-		!strncmp(file, "pl_hoodoo", 9) ||
-		!strncmp(file, "plats", 5) ||
-		!strncmp(file, "player", 6) ||
-		!strncmp(file, "resource", 8) ||
-		!strncmp(file, "replay", 6) ||
-		!strncmp(file, "test", 4) ||
-		!strncmp(file, "ui", 2) ||
-		!strncmp(file, "vehicles", 8) ||
-		!strncmp(file, "vo", 2) ||
-		!strncmp(file, "weapons", 7))
-		return true;
-	else
-		return false;
-}
-
 public IsValidClient (client)
 {
 	if (client <= 0 || client > MaxClients || !IsClientConnected(client) || IsFakeClient(client) || IsClientReplay(client) || IsClientSourceTV(client))


### PR DESCRIPTION
This'll only really work with my [edited SoundLib extension](https://github.com/Adrianilloo/soundlib/releases) that provides analogous support (reading sound files from any gameinfo search path, like VPKs or co-existing server's mod directories, like `hl2`, or custom ones)